### PR TITLE
upgrade gatsby-mdx-embed

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -28,7 +28,7 @@
     "@emotion/styled": "^10.0.14",
     "@mdx-js/mdx": "^1.1.0",
     "@mdx-js/react": "^1.5.5",
-    "@pauliescanlon/gatsby-mdx-embed": "^0.0.16",
+    "@pauliescanlon/gatsby-mdx-embed": "^0.0.17",
     "@testing-library/cypress": "^5.0.1",
     "@theme-ui/presets": "^0.3.0",
     "@theme-ui/prism": "^0.2.14",

--- a/theme/package.json
+++ b/theme/package.json
@@ -28,7 +28,7 @@
     "@emotion/styled": "^10.0.14",
     "@mdx-js/mdx": "^1.1.0",
     "@mdx-js/react": "^1.5.5",
-    "@pauliescanlon/gatsby-mdx-embed": "^0.0.15",
+    "@pauliescanlon/gatsby-mdx-embed": "^0.0.16",
     "@testing-library/cypress": "^5.0.1",
     "@theme-ui/presets": "^0.3.0",
     "@theme-ui/prism": "^0.2.14",

--- a/theme/src/components/layout.tsx
+++ b/theme/src/components/layout.tsx
@@ -1,13 +1,11 @@
 /** @jsx jsx */
 import React from "react"
 import { jsx, Box } from "theme-ui"
-import { MdxEmbedProvider } from "@pauliescanlon/gatsby-mdx-embed"
 import Header from "./Header"
 import Main from "./Main"
 
-// manually add MdxEmbedProvider from gatsby-mdx-embed. The gatsby-browser it uses seems to not get applied correctly.
+
 const Layout: React.FC = ({ children, ...props }) => (
-  <MdxEmbedProvider>
     <Box
       sx={{
         minHeight: `100vh`,
@@ -15,11 +13,10 @@ const Layout: React.FC = ({ children, ...props }) => (
         flexDirection: `column`,
         variant: `styles.Layout`,
       }}
-    >
+      >
       <Header {...props} />
       <Main {...props}>{children}</Main>
     </Box>
-  </MdxEmbedProvider>
 )
 
 export default Layout


### PR DESCRIPTION
Upgrade `gatsby-mdx-embed` to `0.0.17`
Remove manually imported `MdxEmbedProvider` from `layout.tsx`