### PR TITLE
feat: support line numbering in codeblocks

### DIFF
--- a/demo/data/posts/i-want-it-all/index.mdx
+++ b/demo/data/posts/i-want-it-all/index.mdx
@@ -121,7 +121,7 @@ return (
 
 ### Line numbering
 
-```js numberLines=true
+```js numberLines
 exports.slugify = (str) => {
   const slug = str
     .toLowerCase()

--- a/demo/data/posts/i-want-it-all/index.mdx
+++ b/demo/data/posts/i-want-it-all/index.mdx
@@ -76,6 +76,9 @@ const IndexPage = (props) => {
 
 ### Line highlighting? Got it!
 
+Line 4 is **lit**.
+Gettit?
+
 ```js hl=4
 const getShouldHighlightLine = (hl) => {
   if (hl) {
@@ -114,6 +117,42 @@ return (
     )}
   </Highlight>
 );
+```
+
+### Line numbering
+
+```js numberLines=true
+exports.slugify = (str) => {
+  const slug = str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, `-`)
+    .replace(/(^-|-\$)+/g, ``);
+  return slug;
+};
+```
+
+### Everything at the same time
+
+The line numbering can start at an arbitrary number!
+
+```css hl=4,8-9,11,15-16 title=underline.css numberLines=42
+a {
+  color: #dfe5f3;
+  text-decoration: none;
+  background-image: linear-gradient(#222b40, #222b40), linear-gradient(
+      rgb(176, 251, 188),
+      rgb(176, 251, 188)
+    ), linear-gradient(#feb2b2, #feb2b2);
+  background-size: 20px 2px, 100% 2px, 0 2px;
+  background-position: calc(20px * -1) 100%, 100% 100%, 0 100%;
+  background-repeat: no-repeat;
+  transition: background-size 2s linear, background-position 2s linear;
+}
+
+a:hover {
+  background-size: 20px 2px, 0 2px, 100% 2px;
+  background-position: calc(100% + 20px) 100%, 100% 100%, 0 100%;
+}
 ```
 
 ## Useful knowledge

--- a/theme/README.md
+++ b/theme/README.md
@@ -147,14 +147,17 @@ As a result, these codeblocks support syntax highlighting for [a range of langua
 
 Highlighting specific lines is possible by passing a string to the `hl` (short for highlight-lines) attribute when writing a codeblock.
 A title may also be added to the codeblock by passing a string to the `title` attribute when writing a codeblock.
+Numbering lines is possible by passing a `numberLines` attribute.
 
-The string you pass to `hl` should be understood by [node-parse-numeric-range](https://github.com/euank/node-parse-numeric-range).
+The value you pass to `hl` should be understood by [node-parse-numeric-range](https://github.com/euank/node-parse-numeric-range).
+If passing a value to `numberLines`, it should be either `true` (to start the numbering at 1), or a decimal integer (to start the numbering at that number).
 
 The code below will highlight the code inside as the `jsx` language, highlight lines 1,2,3, and 5, and put a small block above it displaying `src/components/CodeBlock.jsx`
+The lines will be numbered starting at 1.
 (Omit the `#` in front of these lines, I only used them here to make the three backticks show up).
 
 ````
-# ```jsx hl=1-3,5 title=src/components/CodeBlock.jsx
+# ```jsx numberLines hl=1-3,5 title=src/components/CodeBlock.jsx
 # import React from 'react'
 # import Highlight, { defaultProps } from 'prism-react-renderer'
 #
@@ -556,3 +559,4 @@ export default theme;
   - [ ] Support different `Page` components for different instances.
 - [ ] PaginationContext and PageContext in BlogPostListPage are duplicated right now
 - [ ] Redo how the `<SEO />` gathers information. It's becoming an a-prop-calypse in there.
+- [x] Support line numbering in codeblocks

--- a/theme/src/components/CodeBlock.tsx
+++ b/theme/src/components/CodeBlock.tsx
@@ -29,10 +29,10 @@ const getShouldHighlightLine = (hl: string | undefined) => {
   return () => false;
 };
 
-const getLineNumberStart = (numberLines: string | undefined) => {
+const getLineNumberStart = (numberLines: string | boolean | undefined) => {
   let result = null;
   if (numberLines) {
-    if (numberLines === `true`) {
+    if (numberLines === `true` || numberLines === true) {
       result = 1;
     } else {
       result = parseInt(numberLines, 10);

--- a/theme/src/components/CodeBlock.tsx
+++ b/theme/src/components/CodeBlock.tsx
@@ -29,11 +29,24 @@ const getShouldHighlightLine = (hl: string | undefined) => {
   return () => false;
 };
 
+const getLineNumberStart = (numberLines: string | undefined) => {
+  let result = null;
+  if (numberLines) {
+    if (numberLines === `true`) {
+      result = 1;
+    } else {
+      result = parseInt(numberLines, 10);
+    }
+  }
+  return result;
+};
+
 const CodeBlock: React.FC<IProps> = ({
   children,
   className: outerClassName,
   title,
   hl,
+  numberLines,
   ...props
 }) => {
   // MDX will pass the language as className
@@ -45,6 +58,8 @@ const CodeBlock: React.FC<IProps> = ({
     return null;
   }
   const shouldHighlightLine = getShouldHighlightLine(hl);
+  const lineNumberStart = getLineNumberStart(numberLines);
+
   return (
     <React.Fragment>
       {title && <div sx={{ variant: `styles.CodeBlock.title` }}>{title}</div>}
@@ -78,6 +93,11 @@ const CodeBlock: React.FC<IProps> = ({
                       : undefined
                   }
                 >
+                  {lineNumberStart && (
+                    <span sx={{ variant: `styles.CodeBlock.lineNumber` }}>
+                      {index + lineNumberStart}
+                    </span>
+                  )}
                   {line.map((token, key) => (
                     <span
                       key={key}

--- a/theme/src/gatsby-plugin-theme-ui/index.js
+++ b/theme/src/gatsby-plugin-theme-ui/index.js
@@ -65,7 +65,7 @@ const theme = merge(tailwind, {
       fontFamily: `monospace`,
       fontSize: 0,
       overflow: `auto`,
-      padding: 3,
+      padding: 2,
       borderRadius: `sm`,
       pre: {
         fontFamily: `monospace`,
@@ -75,15 +75,17 @@ const theme = merge(tailwind, {
         margin: 0,
       },
       highlightLine: {
+        // match padding on entire CodeBlock <div>
+        // padding: 2 == padding: "0.5rem"
         backgroundColor: `#f0f0f0`,
         borderLeftColor: `#49d0c5`,
         borderLeftStyle: `solid`,
-        borderLeftWidth: `0.25em`,
+        borderLeftWidth: `0.25rem`,
         display: `block`,
-        marginRight: `-1em`,
-        marginLeft: `-1em`,
-        paddingRight: `1em`,
-        paddingLeft: `0.75em`,
+        marginRight: `-0.5rem`,
+        marginLeft: `-0.5rem`,
+        paddingRight: `0.5rem`,
+        paddingLeft: `0.25rem`,
       },
       title: {
         fontFamily: `monospace`,
@@ -100,6 +102,15 @@ const theme = merge(tailwind, {
         px: 3,
         fontSize: 0,
         marginTop: 2,
+      },
+      lineNumber: {
+        display: `inline-block`,
+        // to support numbers with 3 digits, swap to table layout: https://codesandbox.io/s/prism-react-renderer-example-u6vhk?file=/src/styles.js
+        width: `2ch`,
+        textAlign: `right`,
+        userSelect: `none`,
+        opacity: 0.3,
+        marginRight: 2,
       },
     },
     inlineCode: {


### PR DESCRIPTION
Using the `numberLines` prop when starting a codeblock with three backticks in `.md` or `.mdx`